### PR TITLE
fix: gemini import문 주석 해제

### DIFF
--- a/bw-ai/llm_router.py
+++ b/bw-ai/llm_router.py
@@ -2,15 +2,15 @@ import os
 from typing import Optional
 from langchain_core.language_models.chat_models import BaseChatModel
 
-from llm.openai_llm import build_openai_llm
-# 배포 환경 안정화를 위해 Gemini provider는 잠시 비활성화합니다.
-# from llm.gemini_llm import build_gemini_llm
+# from llm.openai_llm import build_openai_llm
+# 배포 환경 안정화를 위해 openai provider는 잠시 비활성화함
+from llm.gemini_llm import build_gemini_llm
 
 # 베베슈어 사용 llm 목록
 # 여기서 llm on/off 제어
 REGISTERED_MODELS = {
     "gemini":  build_gemini_llm,
-    "openai":  build_openai_llm,
+    #"openai":  build_openai_llm,
 }
 
 # llm 활성화 여부 확인 


### PR DESCRIPTION
# 연관이슈

# 설명
gemini api를 사용하기 위해 기존에 주석처리했던 from llm.gemini_llm import build_gemini_llm를 다시 적었습니다.

